### PR TITLE
Change test server to the public orion context broker.

### DIFF
--- a/packages/fiware-test/CMakeLists.txt
+++ b/packages/fiware-test/CMakeLists.txt
@@ -59,7 +59,8 @@ target_link_libraries(${PROJECT_NAME}
 
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE
-        "FIWARE__IP__TEST_CONFIG=\"192.168.1.59\""
+        #"FIWARE__IP__TEST_CONFIG=\"192.168.1.59\""
+        "FIWARE__IP__TEST_CONFIG=\"orion.lab.fiware.org\""
         "FIWARE__PORT__TEST_CONFIG=\"1026\""
 )
 


### PR DESCRIPTION
This PR changes the server using for testing to the public Orion ContextBroker.

**Currently isn't working**
- [ ] Verify that the server works again before merge this PR.