### PR TITLE
Tests in localhost

### DIFF
--- a/fiware-test/CMakeLists.txt
+++ b/fiware-test/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(${PROJECT_NAME}
 
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE
-        "FIWARE__IP__TEST_CONFIG=\"192.168.1.139\""
+        "FIWARE__IP__TEST_CONFIG=\"localhost\""
         "FIWARE__PORT__TEST_CONFIG=\"1026\""
 )
 


### PR DESCRIPTION
Jenkins now uses a docker container with contextBroker ready, so the IP for testing is now `localhost`.