### PR TITLE
Testing IP to localhost

### DIFF
--- a/packages/fiware-test/CMakeLists.txt
+++ b/packages/fiware-test/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(${PROJECT_NAME}
 
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE
-        "FIWARE__IP__TEST_CONFIG=\"localhost\""
+        "FIWARE__IP__TEST_CONFIG=\"127.0.0.1\""
         "FIWARE__PORT__TEST_CONFIG=\"1026\""
 )
 

--- a/packages/fiware-test/CMakeLists.txt
+++ b/packages/fiware-test/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(${PROJECT_NAME}
 
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE
-        "FIWARE__IP__TEST_CONFIG=\"192.168.1.59\""
+        "FIWARE__IP__TEST_CONFIG=\"localhost\""
         "FIWARE__PORT__TEST_CONFIG=\"1026\""
 )
 


### PR DESCRIPTION
Jenkins now uses a docker container with contextBroker ready, so the IP for testing is now `localhost`.